### PR TITLE
Fullscreen music window enabler

### DIFF
--- a/1080i/Custom_1121_MusicFullscreenEnabler.xml
+++ b/1080i/Custom_1121_MusicFullscreenEnabler.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<window type="dialog" id="1121">
+    <allowoverlay>no</allowoverlay>
+    <onload condition="!Window.IsActive(visualisation) + !Window.IsActive(videos)">FullScreen</onload>
+    <visible>Player.HasAudio + String.IsEmpty(Window(10025).Property(TvTunesIsAlive))</visible>
+    <visible>![VideoPlayer.Content(LiveTV) + !Pvr.IsPlayingRadio]</visible>
+    <controls></controls>
+</window> 


### PR DESCRIPTION
Fullscreen music window will be visible if Player.HasAudio is true which is true if you start playing music.